### PR TITLE
feat: Initialize Express server after successful MongoDB connection

### DIFF
--- a/MERN/api/index.js
+++ b/MERN/api/index.js
@@ -1,23 +1,24 @@
-import express from 'express';
-import mongoose from 'mongoose';
-import dotenv from 'dotenv';
-import userRouter from './routes/user.route.js';
-import authRouter from './routes/auth.route.js';
-import listingRouter from './routes/listing.route.js';
-import cookieParser from 'cookie-parser';
-import path from 'path';
+import express from "express";
+import mongoose from "mongoose";
+import dotenv from "dotenv";
+import userRouter from "./routes/user.route.js";
+import authRouter from "./routes/auth.route.js";
+import listingRouter from "./routes/listing.route.js";
+import cookieParser from "cookie-parser";
+import path from "path";
 dotenv.config();
 
 mongoose
   .connect(process.env.MONGO)
   .then(() => {
-    console.log('Connected to MongoDB!');
+    console.log("Connected to MongoDB!");
+    startServer();
   })
   .catch((err) => {
     console.log(err);
   });
 
-  const __dirname = path.resolve();
+const __dirname = path.resolve();
 
 const app = express();
 
@@ -25,27 +26,29 @@ app.use(express.json());
 
 app.use(cookieParser());
 
-app.listen(3000, () => {
-  console.log('Server is running on port 3000!');
+app.use("/api/user", userRouter);
+app.use("/api/auth", authRouter);
+app.use("/api/listing", listingRouter);
+
+app.use(express.static(path.join(__dirname, "/client/dist")));
+
+app.get("*", (req, res) => {
+  res.sendFile(path.join(__dirname, "client", "dist", "index.html"));
 });
-
-app.use('/api/user', userRouter);
-app.use('/api/auth', authRouter);
-app.use('/api/listing', listingRouter);
-
-
-app.use(express.static(path.join(__dirname, '/client/dist')));
-
-app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, 'client', 'dist', 'index.html'));
-})
 
 app.use((err, req, res, next) => {
   const statusCode = err.statusCode || 500;
-  const message = err.message || 'Internal Server Error';
+  const message = err.message || "Internal Server Error";
   return res.status(statusCode).json({
     success: false,
     statusCode,
     message,
   });
 });
+
+function startServer() {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Server is running on port ${PORT}!`);
+  });
+}


### PR DESCRIPTION
<h2>Your code is great and it is totally okay to write it this way, especially for simple apps so this is merely a recommendation !</h2>

**Commit:**

- Refactor server initialization to start after establishing a connection to MongoDB
- Ensure server starts only after database connection is successful
- Improve code structure by introducing a separate function for starting the server


<h3>Reasons for the changes:</h3>

Ensures that the server starts listening only after successfully connecting to MongoDB which can be crucial in production environments where database connectivity is essential for the application's functionality.

It also provides more control over the server startup process, allowing you to delay server initialization until all necessary resources are ready otherwise there are risks starting the server before the MongoDB connection is established which might potentially lead to errors or unexpected behavior if the application relies heavily on database operations.

